### PR TITLE
도메인 변경

### DIFF
--- a/app/capstone/apps/account/views.py
+++ b/app/capstone/apps/account/views.py
@@ -61,6 +61,7 @@ def find_user(request):
 
 
 def sendMail(message, mail_title, to_email):
+    print("send mail!!!!!!!!!!!!")
     email = EmailMessage(mail_title, message, to=[to_email])
     email.send()
 

--- a/app/capstone/settings/deploy.py
+++ b/app/capstone/settings/deploy.py
@@ -1,4 +1,5 @@
 from .base import *
 
 DEBUG = False
-ALLOWED_HOSTS = ["moongedrive.com"]
+ALLOWED_HOSTS = ["moongedrive.com", "moongedrive.xyz", "52.79.112.227"]
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,7 @@ services:
       - ./nginx/certbot/conf:/etc/letsencrypt
       - ./nginx/certbot/www:/var/www/certbot
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+
   certbot:
     image: certbot/certbot
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,6 @@ services:
       - ./file/complete:/media/files/ #사용자가 업로한 파일들을 저장하는 장소
       - ./file/thumbnail:/media/thumbnail/
       - ./React:/React/
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf #nginx 테스트용입니다. 나중에 지워주세요.
     ports:
       - "80:80"
     depends_on:

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -29,10 +29,10 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
-domains=(moongedrive.com www.moongedrive.com)
+domains=(moongedrive.xyz www.moongedrive.xyz)
 rsa_key_size=4096
 data_path="./nginx/certbot"
-email=""
+email="sungs201@naver.com"
 staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
 
 if [ -d "$data_path" ]; then

--- a/nginx/app.prod.conf
+++ b/nginx/app.prod.conf
@@ -4,7 +4,7 @@ upstream django {
 
 server {
     listen 80;
-    server_name moongedrive.com;
+    server_name moongedrive.xyz;
 
     location / {
         return 301 https://$host$request_uri;
@@ -17,13 +17,13 @@ server {
 
 server {
     listen 443 ssl;
-    server_name moongedrive.com;
+    server_name moongedrive.xyz;
     charset UTF-8;
     client_max_body_size 5G;
     root /;
 
-    ssl_certificate /etc/letsencrypt/live/moongedrive.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/moongedrive.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/moongedrive.xyz/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/moongedrive.xyz/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
@@ -59,3 +59,5 @@ server {
             include uwsgi_params;
     }
 }
+
+


### PR DESCRIPTION
팀 프로젝트는 끝났지만, 개인적으로 사이트를 좀 더 보완하고 싶어 기존에 사용하던 도메인 대신, 새로 moongedrive.xyz라는 도메인을 구매했다. 이를 적용하기 위해 docker-compose 설정 파일과 nginx 설정 파일의 도메인을 수정했다. 